### PR TITLE
Fix lottie-web server side error

### DIFF
--- a/app/melotomorrow_old/components/Preloader.tsx
+++ b/app/melotomorrow_old/components/Preloader.tsx
@@ -1,6 +1,5 @@
-"use client"
+"use client";
 
-import lottie from 'lottie-web';
 import { useEffect, useRef } from 'react';
 
 const Preloader: React.FC = () => {
@@ -8,20 +7,26 @@ const Preloader: React.FC = () => {
   const animationInstance = useRef<any>(null);
 
   useEffect(() => {
-    if (animationContainer.current && !animationInstance.current) {
-      animationInstance.current = lottie.loadAnimation({
-        container: animationContainer.current,
-        renderer: 'svg',
-        loop: false,
-        autoplay: true,
-        path: '/loading.json',
-      });
-      animationInstance.current?.setSpeed(1.4);
-      return () => {
-        animationInstance.current?.destroy();
-        animationInstance.current = null;
-      };
-    }
+    let mounted = true;
+    (async () => {
+      const lottie = await import('lottie-web');
+      if (mounted && animationContainer.current && !animationInstance.current) {
+        animationInstance.current = lottie.default.loadAnimation({
+          container: animationContainer.current,
+          renderer: 'svg',
+          loop: false,
+          autoplay: true,
+          path: '/loading.json',
+        });
+        animationInstance.current?.setSpeed(1.4);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      animationInstance.current?.destroy();
+      animationInstance.current = null;
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent server-side `document is not defined` error from lottie-web
- dynamically import `lottie-web` in the Preloader component

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68433fa86ac8833095749a3f8c577239